### PR TITLE
Map add geocoder gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ gem "devise"
 # Seed Gem
 gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
 
+# Geocoder - map gem
+gem "geocoder"
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,6 +122,7 @@ GEM
     ffi (1.15.5)
     font-awesome-sass (6.1.2)
       sassc (~> 2.0)
+    geocoder (1.8.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -272,6 +273,7 @@ DEPENDENCIES
   dotenv-rails
   faker!
   font-awesome-sass (~> 6.1)
+  geocoder
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/models/game_world.rb
+++ b/app/models/game_world.rb
@@ -1,4 +1,6 @@
 class GameWorld < ApplicationRecord
   belongs_to :user
   has_many :reservations
+  geocoded_by :address
+  after_validation :geocode, if: :will_save_change_to_address?
 end

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,27 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  # lookup: :nominatim,         # name of geocoding service (symbol)
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  # api_key: nil,               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  units: :km,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+
+  # Cache configuration
+  # cache_options: {
+  #   expiration: 2.days,
+  #   prefix: 'geocoder:'
+  # }
+)

--- a/db/migrate/20220818151123_add_coordinates_to_game_worlds.rb
+++ b/db/migrate/20220818151123_add_coordinates_to_game_worlds.rb
@@ -1,0 +1,6 @@
+class AddCoordinatesToGameWorlds < ActiveRecord::Migration[7.0]
+  def change
+    add_column :game_worlds, :latitude, :float
+    add_column :game_worlds, :longitude, :float
+  end
+end

--- a/db/migrate/20220818152001_add_address_column_to_game_worlds.rb
+++ b/db/migrate/20220818152001_add_address_column_to_game_worlds.rb
@@ -1,0 +1,5 @@
+class AddAddressColumnToGameWorlds < ActiveRecord::Migration[7.0]
+  def change
+    add_column :game_worlds, :address, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_18_151123) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_18_152001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_18_151123) do
     t.datetime "updated_at", null: false
     t.float "latitude"
     t.float "longitude"
+    t.string "address"
     t.index ["user_id"], name: "index_game_worlds_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_16_184252) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_18_151123) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,6 +20,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_16_184252) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.float "latitude"
+    t.float "longitude"
     t.index ["user_id"], name: "index_game_worlds_on_user_id"
   end
 


### PR DESCRIPTION
Added
-added geocoding gem
-generated migration game world table for latitude and longitude, as floats.
-generated migration for game world table for address, as string.

To test:
-bundle install
-# rails console
-gameworld001 = GameWorld.create(address: "16 Villa Gaudelet, Paris", name: "Le Wagon HQ")
-GameWorld.near(address: "15 Villa Gaudelet, Paris", 5)
