### PR TITLE
Add photos to game worlds and refactored seed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 puts "Deleting all the models..."
 Reservation.destroy_all
 GameWorld.destroy_all
@@ -27,6 +29,15 @@ main_game_worlds = [
   )
 ]
 
+mario_image = URI.open("https://res.cloudinary.com/hollywoodxj/image/upload/v1660765087/super-mario-sunshine-button-1599246426728_b3hfau.jpg")
+main_game_worlds[0].photos.attach(io: mario_image, filename: 'mario.jpg')
+
+pokemon_image = URI.open("https://res.cloudinary.com/hollywoodxj/image/upload/v1660765095/Pokemon_Sword_qxxzuj.jpg")
+main_game_worlds[1].photos.attach(io: pokemon_image, filename: 'pokemon.jpg')
+
+zelda_image = URI.open("https://res.cloudinary.com/hollywoodxj/image/upload/v1660765076/zeldaoot-ignart-1638901927766_csbbsu.jpg")
+main_game_worlds[2].photos.attach(io: zelda_image, filename: 'zelda.jpg')
+
 main_game_worlds.each do |game_world|
   game_world.user = main_user
   game_world.save!
@@ -52,14 +63,24 @@ reservation2.save!
 puts "Successfully created reservation linked to #{reservation2.game_world.name}"
 
 reservation3 = Reservation.new(
-  start_date: Date.new(2022, 8, 5),
-  end_date: Date.new(2022, 8, 8),
+  start_date: Date.new(2022, 9, 1),
+  end_date: Date.new(2022, 9, 8),
   status: 2
 )
-reservation3.game_world = GameWorld.find_by(name: 'The Legend of Zelda: Ocarina of Time')
+reservation3.game_world = GameWorld.find_by(name: 'Pokemon Sword')
 reservation3.user = main_user
 reservation3.save!
 puts "Successfully created reservation linked to #{reservation3.game_world.name}"
+
+reservation4 = Reservation.new(
+  start_date: Date.new(2022, 8, 5),
+  end_date: Date.new(2022, 8, 8),
+  status: 3
+)
+reservation4.game_world = GameWorld.find_by(name: 'The Legend of Zelda: Ocarina of Time')
+reservation4.user = main_user
+reservation4.save!
+puts "Successfully created reservation linked to #{reservation4.game_world.name}"
 
 puts 'Main data successfully added'
 puts '--------------------------------'
@@ -79,6 +100,9 @@ puts 'Generating random users, game worlds and reservations...'
     description: Faker::Quote.yoda
   )
 
+  game_image = URI.open("https://picsum.photos/500/500")
+  game_world.photos.attach(io: game_image, filename: 'pokemon.jpg')
+
   game_world.user = user
   game_world.save!
 
@@ -90,11 +114,21 @@ puts 'Generating random users, game worlds and reservations...'
 
   reservation.user = user
   reservation.game_world = game_world
-
   reservation.save!
+
+  reservation2 = Reservation.new(
+    start_date: Faker::Date.between(from: '2021-07-23', to: '2021-09-25'),
+    end_date: Faker::Date.between(from: '2021-09-26', to: '2021-10-12'),
+    status: 3
+  )
+
+  reservation2.user = user
+  reservation2.game_world = game_world
+  reservation2.save!
 
   puts "Successfully created #{game_world.name} associated to #{user.username}"
   puts "Successfully created reservation from #{user.username} for #{game_world.name} world with id: #{reservation.id}"
+  puts "Successfully created done reservation from #{user.username} for #{game_world.name} world with id: #{reservation2.id}"
   puts "Last reservation start date: #{reservation.start_date}, end date #{reservation.end_date}"
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,7 @@ puts "Creating the main user..."
 main_user = User.create(username: "airbingame", email: "a@a.a", password: "abc1234")
 puts "Main user #{main_user.username} created"
 
+puts "Creating main game worlds..."
 main_game_worlds = [
   GameWorld.new(
     name: 'Super Mario Sunshine',
@@ -41,8 +42,10 @@ main_game_worlds[2].photos.attach(io: zelda_image, filename: 'zelda.jpg')
 main_game_worlds.each do |game_world|
   game_world.user = main_user
   game_world.save!
+  puts "Game World #{game_world.name} successfully saved"
 end
 
+puts "Creating main reservations..."
 reservation1 = Reservation.new(
   start_date: Date.new(2022, 8, 23),
   end_date: Date.new(2022, 8, 27),
@@ -86,7 +89,7 @@ puts 'Main data successfully added'
 puts '--------------------------------'
 
 puts 'Generating random users, game worlds and reservations...'
-20.times do
+9.times do
   user = User.create(
     username: Faker::Internet.username(specifier: 10),
     email: Faker::Internet.email,
@@ -100,8 +103,8 @@ puts 'Generating random users, game worlds and reservations...'
     description: Faker::Quote.yoda
   )
 
-  game_image = URI.open("https://picsum.photos/500/500")
-  game_world.photos.attach(io: game_image, filename: 'pokemon.jpg')
+  game_image = URI.open("https://res.cloudinary.com/hollywoodxj/image/upload/v1660873436/development/a8rf1tas3q2xoikq5vl1ijtl43i8.jpg")
+  game_world.photos.attach(io: game_image, filename: 'wow.jpg')
 
   game_world.user = user
   game_world.save!


### PR DESCRIPTION
What has changed:
- Attached photos to our 3 main game worlds wheen seeding
- Attached WoW photo to other genereated game worlds
- Reduced the number of created game worlds to 9
- Added informations of the created elements in the console

How to test:
`rails db:seed`

Screen:
<img width="740" alt="image" src="https://user-images.githubusercontent.com/49365826/185662653-bcdbb3ee-1779-4565-9e1b-d219fc6fbb40.png">

Please review @MikaelJG 